### PR TITLE
20: [Feat] Select and play a level

### DIFF
--- a/data/levels.json
+++ b/data/levels.json
@@ -1,0 +1,46 @@
+{
+	"levels": [
+		{
+			"id": "020326",
+			"level": "2 March 2026",
+			"difficulty": "easy",
+			"name": "Anthony",
+			"origin": "Wales"
+		},
+		{
+			"id": "090326",
+			"level": "9 March 2026",
+			"difficulty": "easy",
+			"name": "Bellamy",
+			"origin": "France"	
+		},
+		{
+			"id": "160326",
+			"level": "16 March 2026",
+			"difficulty": "easy",
+			"name": "Fujikawa",
+			"origin": "Japan"	
+		},
+			{
+			"id": "230326",
+			"level": "23 March 2026",
+			"difficulty": "intermediate",
+			"name": "Furlong",
+			"origin": "England"	
+		},
+		{
+			"id": "300326",
+			"level": "30 March 2026",
+			"difficulty": "intermediate",
+			"name": "Gabriel",
+			"origin": "England"	
+		},
+		{
+			"id": "060426",
+			"level": "6 April 2026",
+			"difficulty": "easy",
+			"name": "Gill",
+			"origin": "Ireland"	
+		}
+	]
+}

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
       </aside>
     	<article>
 		  		<h2>
-		  			<a><time datetime="2025-10-04">Sat 8<sup>th</sup> Nov 2025</time></a>
+		  			<a id="level-title"><time id="level-title-time"><sup id="level-title-time-sup"></sup></time></a>
 		  			<img src="images/globe.svg" alt="streak">
 						<!-- https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog#specifications -->
 						<button id="more-btn"><code>More</code></button>
@@ -68,7 +68,7 @@
 						  </p>
 							<div id="controls">
 								<button id="restart-btn"><code>Restart</code></button>
-								<button id="level-btn"><code>Levels</code></button>
+								<button id="levels-btn"><code>Levels</code></button>
 								<button id="how-to-play-btn"><code>How to Play</code></button>
 							  <button id="faq-btn"><code>FAQ</code></button>
 							  <button id="settings-btn"><code>Settings</code></button>
@@ -114,12 +114,8 @@
 											    }
 											  </style>
 										</svg>
-										<svg width="300" height="60"><rect x="5" y="5" width="290" height="50" stroke="#00A878" stroke-width="5px" rx="10px" ry="10px" stroke-linejoin="round" fill-opacity="0.5" fill="#00A878"></rect><text x="30" y="35" fill="white">14th Nov 25</text><text x="180" y="35" fill="white">easy</text></svg>
-										<svg width="300" height="60"><rect x="5" y="5" width="290" height="50" stroke="#00A878" stroke-width="5px" rx="10px" ry="10px" stroke-linejoin="round" fill-opacity="0.5" fill="#00A878"></rect><text x="30" y="35" fill="white">21st Nov 25</text><text x="180" y="35" fill="white">easy</text></svg>
-										<svg width="300" height="60"><rect x="5" y="5" width="290" height="50" stroke="#00A6ED" stroke-width="5px" rx="10px" ry="10px" stroke-linejoin="round" fill-opacity="0.5" fill="#00A6ED"></rect><text x="30" y="35" fill="white">28th Nov 25</text><text x="180" y="35" fill="white">intermediate</text></svg>
-										<svg width="300" height="60"><rect x="5" y="5" width="290" height="50" stroke="#FFB400" stroke-width="5px" rx="10px" ry="10px" stroke-linejoin="round" fill-opacity="0.5" fill="#FFB400"></rect><text x="30" y="35" fill="white">5th Dec 25</text><text x="180" y="35" fill="white">hard</text></svg>
-										<svg width="300" height="60"><rect x="5" y="5" width="290" height="50" stroke="#00A6ED" stroke-width="5px" rx="10px" ry="10px" stroke-linejoin="round" fill-opacity="0.5" fill="#00A6ED"></rect><text x="30" y="35" fill="white">12th Dec 25</text><text x="180" y="35" fill="white">intermediate</text></svg>
-										<svg width="300" height="60"><rect x="5" y="5" width="290" height="50" stroke="#00A6ED" stroke-width="5px" rx="10px" ry="10px" stroke-linejoin="round" fill-opacity="0.5" fill="#00A6ED"></rect><text x="30" y="35" fill="white">19th Dec 25</text><text x="180" y="35" fill="white">intermediate</text></svg>
+										<button type="submit" class="level"><svg width="300" height="60"><rect x="5" y="5" width="290" height="50" stroke="#00A6ED" stroke-width="5px" rx="10px" ry="10px" stroke-linejoin="round" fill-opacity="0.5" fill="#00A6ED"></rect><text x="30" y="35" fill="white">28th Nov 25</text><text x="180" y="35" fill="white">intermediate</text></svg>
+										</button>
 						    	</div>
 						    </div>
 						  <button class="close">Close</button>
@@ -157,17 +153,17 @@
 
 		  <article>
 		    <p>Guess the origin country of the surname below.</p>
-		    <h2>"Morgan"</h2>
+		    <h2 id="family-name">"Morgan"</h2>
 	    	<img src="images/bulb2.svg" alt="streak">
     		<form>
-        	<input type="text" id="name" name="country_name" placeholder="Enter a country" required>
+        	<input type="text" id="guess" name="country_name" placeholder="Enter a country" required>
         	<button type="submit" id="submit">▶︎</button>
         </form>
         <div id="tags">
         </div>
     	</article>
 
-    	<div id="guesses">
+    	<div id="guessed-cards-container">
 				<svg width="1" height="1">
 					  <style>
 					    /* Define the font family using web fonts */

--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
   </head>
 
   <body>
+  	<script>0</script>
     <nav>
       <ul>
         <li>
@@ -127,8 +128,7 @@
 						<dialog id="howToPlayDialog" closedby="any">
 						  <h2><code>How to Play</code></h2>
 						  <p>
-						    Closable using the "Close" button, the Esc key, or by clicking outside the
-						    dialog. "Light dismiss" behavior.
+						  	The distance between two countries is based on bilateral distances between the biggest cities of those two countries
 						  </p>
 						  <button class="close">Close</button>
 						</dialog>

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -1,0 +1,16 @@
+const CONTAINER = {
+	GUESSES: "guesses",
+	LEVELS: "levels"
+}
+
+const COUNTRY_CARD = {
+	WIDTH: 270,
+	HEIGHT: 50
+}
+
+const LEVEL_CARD = {
+	WIDTH: 290,
+	HEIGHT: 50
+}
+
+export { CONTAINER, COUNTRY_CARD, LEVEL_CARD };

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -1,10 +1,10 @@
 const CONTAINER = {
-	GUESSES: "guesses",
+	GUESSED_CARDS: "guessed-cards-container",
 	LEVELS: "levels"
 }
 
-const COUNTRY_CARD = {
-	WIDTH: 270,
+ const COUNTRY_CARD = {
+	WIDTH: 290,
 	HEIGHT: 50
 }
 
@@ -13,4 +13,12 @@ const LEVEL_CARD = {
 	HEIGHT: 50
 }
 
-export { CONTAINER, COUNTRY_CARD, LEVEL_CARD };
+const TEXT_COORDINATES = {
+	X: 30,
+	Y: 180
+}
+
+const LEVEL_CLASS = "level";
+const CARD_PADDING = 10;
+
+export { CONTAINER, COUNTRY_CARD, LEVEL_CARD, TEXT_COORDINATES, LEVEL_CLASS, CARD_PADDING };

--- a/scripts/local-storage.js
+++ b/scripts/local-storage.js
@@ -1,91 +1,103 @@
 import { LevelStatus } from "./models/levels.js";
 import { isEmpty } from "./util/object.js";
 import { ENTITY_COLOURS } from "./models/entity-colours.js";
-import { displayCard } from "./svg.js";
+import { createCardElement } from "./svg.js";
+import { CONTAINER, COUNTRY_CARD, LEVEL_CARD } from "./constants.js";
 
-export function saveLocalStorage(id, levelTitle, guess, lastLevelOpen=undefined, additionalHintsUsed=0) {
+export function saveLocalStorage(
+	userId,
+	levelId,
+	levelTitle,
+	guess,
+	additionalHintsUsed = 0,
+) {
 	let storedLevels = JSON.parse(localStorage.getItem("levels"));
 	let storedLevel;
 	if (storedLevels) {
-		storedLevel = storedLevels.find((l) => l.title == levelTitle);
+		storedLevel = storedLevels.find((l) => l.id == levelId);
 		if (storedLevel) {
 			storedLevel.guesses.push(guess);
 		} else {
-			storedLevel = makeLevel(levelTitle, additionalHintsUsed, guess);
+			storedLevel = makeLevel(levelId, levelTitle, additionalHintsUsed, guess);
 			storedLevels.push(storedLevel);
 		}
 	} else {
 		storedLevels = [];
-		storedLevel = makeLevel(levelTitle, additionalHintsUsed, guess);
+		storedLevel = makeLevel(levelId, levelTitle, additionalHintsUsed, guess);
 		storedLevels.push(storedLevel);
 	}
-	
+
 	localStorage.setItem("levels", JSON.stringify(storedLevels));
-	
-	let storedLastLevelOpen = localStorage.getItem("lastLevelOpen");
-	if (!storedLastLevelOpen) {
-		localStorage.setItem("lastLevelOpen", lastLevelOpen);
-	} else if (storedLastLevelOpen != lastLevelOpen) {
-		localStorage.setItem("lastLevelOpen", storedLastLevelOpen);
+
+	let storedLastLevelIdOpen = localStorage.getItem("lastLevelIdOpen");
+	if (!storedLastLevelIdOpen) {
+		localStorage.setItem("lastLevelIdOpen", levelId);
+	} else if (storedLastLevelIdOpen != levelId) {
+		localStorage.setItem("lastLevelIdOpen", storedLastLevelIdOpen);
 	}
 }
 
 function isUserExisting(id) {
-	const storedId = localStorage.getItem("id");
+	const storedId = localStorage.getItem("userId");
 	return id === storedId;
 }
 
-export function getId() {
-  let id = localStorage.getItem("id");
-  if (!id | !isUserExisting(id)) {
-    id = uuidv4();
-    localStorage.setItem("id", id);
-  }
-  return id;
+export function getUserId() {
+	let id = localStorage.getItem("userId");
+	if (!id | !isUserExisting(id)) {
+		id = uuidv4();
+		localStorage.setItem("userId", id);
+	}
+	return id;
 }
 
-function makeLevel(title, hintsUsed, guess) {
+function makeLevel(levelId, level, hintsUsed, guess) {
 	const guesses = [];
 	guesses.push(guess);
-	const level = {
-		"id": generateDateId(title),
-		"title": title,
-		"status": LevelStatus.inProgress,
-		"hintsUsed": hintsUsed,
-		"guesses": guesses
+	const newLevelObj = {
+		id: levelId,
+		title: level,
+		status: LevelStatus.inProgress,
+		hintsUsed: hintsUsed,
+		guesses: guesses,
 	};
-	return level;
-}
-
-export function generateDateId(dateString) {
-	const date = new Date(dateString);
-	const dateId = [date.getDate(), date.getMonth(), date.getYear()];
-	return dateId.join("");
+	return newLevelObj;
 }
 
 /**
  * Display country cards for this level.
- * @param {number} guess The level id to generate cards for.
+ * @param {number} the level id to generate guessed cards for.
  * @return {undefined}
  */
-export function loadLevelCards(levelId) {
-  let storedLevels = JSON.parse(localStorage.getItem("levels"));
-  if (storedLevels) {
-    const level = storedLevels.find((l) => l.id == levelId);
-	  level.guesses.forEach(guess => {
-	    const titleCasedGuess = guess.country;
-	    displayCard(titleCasedGuess, `${guess.distance}km`, ENTITY_COLOURS[titleCasedGuess]);    
-	  });
-  }
+export function loadGuessCards(levelId) {
+	let storedLevels = JSON.parse(localStorage.getItem("levels"));
+	if (storedLevels) {
+		const level = storedLevels.find((l) => l.id == levelId);
+		if (level) {
+			level.guesses.forEach((guess) => {
+				createCardElement(
+					guess.country,
+					`${guess.distance}km`,
+					ENTITY_COLOURS[guess.country],
+					CONTAINER.GUESSED_CARDS,
+					LEVEL_CARD.WIDTH,
+					LEVEL_CARD.HEIGHT,
+				);
+			});
+		}
+	}
 }
 
 // Source - https://stackoverflow.com/a/2117523
 // Posted by broofa, modified by community. See post 'Timeline' for change history
 // Retrieved 2026-01-13, License - CC BY-SA 4.0
 function uuidv4() {
-  return "10000000-1000-4000-8000-100000000000".replace(/[018]/g, c =>
-    (+c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> +c / 4).toString(16)
-  );
+	return "10000000-1000-4000-8000-100000000000".replace(/[018]/g, (c) =>
+		(
+			+c ^
+			(crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (+c / 4)))
+		).toString(16),
+	);
 }
 
 function iterateStatus(status) {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,4 +1,5 @@
-import { ENTITY_COLOURS } from "./models/entity-colours.js";
+import { COLOUR, ENTITY_COLOURS } from "./models/entity-colours.js";
+import { CONTAINER, COUNTRY_CARD, LEVEL_CARD } from "./constants.js";
 import {
   saveLocalStorage,
   getId,
@@ -85,7 +86,23 @@ export async function fetchJsonFile(filename) {
   return data;
 }
 
+function loadLevels() {
+  fetchJsonFile("data/levels.json").then((data) => {
+    for (const l of data.levels) {
+      displayCard(
+        l.level,
+        l.difficulty,
+        COLOUR.FRESH_SKY,
+        CONTAINER.LEVELS,
+        LEVEL_CARD.WIDTH,
+        LEVEL_CARD.HEIGHT,
+      );
+    }
+  });
+}
+
 function main() {
+  loadLevels();
   handleDialog();
   const origin = "Wales";
 
@@ -138,11 +155,13 @@ function main() {
         } else {
           guess.distance = Math.round(data.distances[guess.country][origin]);
           saveLocalStorage(getId(), currentLevel, guess, currentLevel, 0);
-          console.log(`displayCard ${titleCasedGuess} ${ENTITY_COLOURS[titleCasedGuess]}`);
           displayCard(
             titleCasedGuess,
             `${guess.distance}km`,
             ENTITY_COLOURS[titleCasedGuess],
+            CONTAINER.GUESSES,
+            COUNTRY_CARD.WIDTH,
+            COUNTRY_CARD.HEIGHT,
           );
         }
       }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,13 +1,12 @@
 import { COLOUR, ENTITY_COLOURS } from "./models/entity-colours.js";
-import { CONTAINER, COUNTRY_CARD, LEVEL_CARD } from "./constants.js";
+import { CONTAINER, COUNTRY_CARD, LEVEL_CARD, LEVEL_CLASS } from "./constants.js";
 import {
   saveLocalStorage,
-  getId,
-  generateDateId,
-  loadLevelCards,
+  getUserId,
+  loadGuessCards,
 } from "./local-storage.js";
 import { toTitleCase, isGuessValid, isGuessADuplicate } from "./util/guess.js";
-import { displayCard } from "./svg.js";
+import { createCardElement } from "./svg.js";
 import {
   duplicateGuessErrorMessage,
   invalidCountryErrorMessage,
@@ -19,7 +18,7 @@ import {
 function handleDialog() {
   const moreBtn = document.getElementById("more-btn");
   const restartBtn = document.getElementById("restart-btn");
-  const levelBtn = document.getElementById("level-btn");
+  const levelsBtn = document.getElementById("levels-btn");
   const howToPlayBtn = document.getElementById("how-to-play-btn");
   const faqBtn = document.getElementById("faq-btn");
   const settingsBtn = document.getElementById("settings-btn");
@@ -42,7 +41,7 @@ function handleDialog() {
     restartDialog.showModal();
   });
 
-  levelBtn.addEventListener("click", () => {
+  levelsBtn.addEventListener("click", () => {
     handleDialogClose(closeBtns);
     levelDialog.showModal();
   });
@@ -86,35 +85,85 @@ export async function fetchJsonFile(filename) {
   return data;
 }
 
-function loadLevels() {
-  fetchJsonFile("data/levels.json").then((data) => {
-    for (const l of data.levels) {
-      displayCard(
-        l.level,
-        l.difficulty,
-        COLOUR.FRESH_SKY,
-        CONTAINER.LEVELS,
-        LEVEL_CARD.WIDTH,
-        LEVEL_CARD.HEIGHT,
-      );
-    }
-  });
+function loadLevelTitle(levelData) {
+  const familyName = document.getElementById('family-name');
+  familyName.innerHTML = `"${levelData.name}"`;
+
+  const levelTitle = levelData.level.split(" ");
+
+  // classify date into correct superscripts 
+  let superscript = 'th';
+  const date = levelTitle[0].slice(-1);
+  switch (date) {
+    case "1":
+      superscript = 'st';
+      break;
+    case "2":
+      superscript = 'nd';
+      break;
+    case "3":
+      superscript = 'rd';
+      break;
+  }
+  
+  const levelTitleTimeContent = `${levelTitle[0]}<sup>${superscript}</sup> ${levelTitle[1]} ${levelTitle[2]}`
+  const levelTitleTime = document.getElementById('level-title-time');
+  levelTitleTime.innerHTML = levelTitleTimeContent
+}
+
+function removeOnScreenGuessCards() {
+  document.querySelectorAll('.guess-card').forEach(e => e.remove());
+}
+
+export function loadLevelHandler(levelData) {
+  loadLevelTitle(levelData);
+  removeOnScreenGuessCards();
+  loadGuessCards(levelData.id);
+  localStorage.setItem("lastLevelIdOpen", levelData.id);
+
+  const closeBtns = document.querySelectorAll(".close");
+  handleDialogClose(closeBtns);
+}
+
+function loadLevelCards(allLevelsData) {
+  for (const l of allLevelsData) {
+    createCardElement(
+      l.level,
+      l.difficulty,
+      COLOUR.FRESH_SKY,
+      CONTAINER.LEVELS,
+      LEVEL_CARD.WIDTH,
+      LEVEL_CARD.HEIGHT,
+      true,
+      l
+    )
+  };
+}
+
+function loadCurrentLevel(allLevels) {
+  let currentLevel;
+  let currentLevelId = localStorage.getItem("lastLevelIdOpen");
+  if (currentLevelId) {
+    currentLevel = allLevels.find((level) => level.id == currentLevelId);
+    loadGuessCards(currentLevelId);
+  } else {
+    currentLevel = allLevels[allLevels.length - 1] // default is latest level
+  }
+  return currentLevel;
 }
 
 function main() {
-  loadLevels();
-  handleDialog();
-  const origin = "Wales";
+  let currentLevel;
+  let allLevelsData;
+  // initial level load in
+  fetchJsonFile("data/levels.json").then((rawLevelsData) => {
+    allLevelsData = rawLevelsData.levels;
+    loadLevelCards(allLevelsData);
+    currentLevel = loadCurrentLevel(allLevelsData);
+    loadLevelTitle(currentLevel);
+  });
 
-  let currentLevel = localStorage.getItem("lastLevelOpen");
-  let currentLevelId;
-  if (currentLevel) {
-    currentLevelId = generateDateId(currentLevel);
-    loadLevelCards(currentLevelId);
-  } else {
-    currentLevel = "26 Jan 25"; // TODO: implement level select
-    currentLevelId = generateDateId(currentLevel);
-  }
+  handleDialog();
 
   const formElem = document.querySelector("form");
   formElem.addEventListener("submit", (e) => {
@@ -126,40 +175,43 @@ function main() {
   });
 
   formElem.addEventListener("formdata", (e) => {
-    console.log("formdata fired");
-
-    // Get the form data from the event object
-    const data = e.formData;
-
     let guess = {
       country: undefined,
       distance: undefined,
     };
-    for (const value of data.values()) {
+    for (const value of e.formData.values()) {
       guess.country = value;
     }
 
     fetchJsonFile("data/comprehensive_country_distances.json").then((data) => {
-      const titleCasedGuess = toTitleCase(guess.country);
       if (!isGuessValid(guess.country, data.distances)) {
         displayErrorMessage(
           `${guess.country} ${invalidCountryErrorMessage}`,
           invalidCountryTag,
         );
       } else {
-        if (isGuessADuplicate(guess, currentLevelId)) {
+        // handle a user changing between levels
+        let currentLevelId = localStorage.getItem("lastLevelIdOpen");  
+        if (currentLevelId) {
+          if (currentLevelId != currentLevel.id) {
+            currentLevel = allLevelsData.find((level) => level.id == currentLevelId);
+          }
+        }
+        if (isGuessADuplicate(guess, currentLevel.id)) {
           displayErrorMessage(
             `${guess.country} ${duplicateGuessErrorMessage}`,
             duplicateGuessTag,
           );
         } else {
-          guess.distance = Math.round(data.distances[guess.country][origin]);
-          saveLocalStorage(getId(), currentLevel, guess, currentLevel, 0);
-          displayCard(
-            titleCasedGuess,
+          guess.country = toTitleCase(guess.country);
+          let distance = Math.round(data.distances[guess.country][currentLevel.origin])
+          guess.distance = guess.country == currentLevel.origin ? 0 : distance;
+          saveLocalStorage(getUserId(), currentLevel.id, currentLevel.level, guess, 0);
+          createCardElement(
+            guess.country,
             `${guess.distance}km`,
-            ENTITY_COLOURS[titleCasedGuess],
-            CONTAINER.GUESSES,
+            ENTITY_COLOURS[guess.country],
+            CONTAINER.GUESSED_CARDS,
             COUNTRY_CARD.WIDTH,
             COUNTRY_CARD.HEIGHT,
           );

--- a/scripts/svg.js
+++ b/scripts/svg.js
@@ -33,22 +33,24 @@ function getText(x, text) {
   return textNS;
 }
 
-export function displayCard(country, distance, colour) {
-  const countryCardWidth = 270;
-  const countryCardHeight = 50;
+export function displayCard(title, metadata, colour, container, width, height) {
+  if (!width && !height) {
+    return;
+  }
   const padding = 10;
-  let svg = getSvg(countryCardWidth + padding, countryCardHeight + padding);
-  const guessesContainer = "guesses";
-  let node = document.getElementById(guessesContainer);
-  node.appendChild(svg);
+  let svg = getSvg(width + padding, height + padding);
+  let node = document.getElementById(container);
+  if (node) {
+    node.appendChild(svg);
+  }
 
-  let r = getRect(colour, countryCardWidth, countryCardHeight);
+  let r = getRect(colour, width, height);
   svg.appendChild(r);
 
   const textCoordinateX = "30";
   const textCoordinateY = "180";
-  let t1 = getText(textCoordinateX, country);
+  let t1 = getText(textCoordinateX, title);
   svg.appendChild(t1);
-  let t2 = getText(textCoordinateY, distance);
+  let t2 = getText(textCoordinateY, metadata);
   svg.appendChild(t2);
 }

--- a/scripts/svg.js
+++ b/scripts/svg.js
@@ -1,14 +1,18 @@
-// Handle the creation of svgs for use in HTML
+/* Dynamically create svgs and elements for use in HTML */
+
+import { loadLevelHandler } from "./main.js";
+import { TEXT_COORDINATES, LEVEL_CLASS, CARD_PADDING } from "./constants.js";
 
 // https://developer.mozilla.org/en-US/docs/Web/SVG/Guides/Scripting
-function getSvg(width, height) {
+function createSvgElement(width, height, className) {
   let svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
   svg.setAttributeNS(null, "width", width);
   svg.setAttributeNS(null, "height", height);
+  svg.setAttributeNS(null, "class", className);
   return svg;
 }
 
-function getRect(colour, width, height) {
+function createRectElement(colour, width, height) {
   let rect = document.createElementNS("http://www.w3.org/2000/svg", "rect");
   rect.setAttributeNS(null, "x", "5");
   rect.setAttributeNS(null, "y", "5");
@@ -24,7 +28,7 @@ function getRect(colour, width, height) {
   return rect;
 }
 
-function getText(x, text) {
+function createTextElement(x, text) {
   const textNS = document.createElementNS("http://www.w3.org/2000/svg", "text");
   textNS.setAttributeNS(null, "x", x);
   textNS.setAttributeNS(null, "y", "35");
@@ -33,24 +37,57 @@ function getText(x, text) {
   return textNS;
 }
 
-export function displayCard(title, metadata, colour, container, width, height) {
-  if (!width && !height) {
+function createButtonElement(type, id, className) {
+  const buttonNS = document.createElementNS(
+    "http://www.w3.org/1999/xhtml",
+    "button",
+  );
+  buttonNS.setAttributeNS(null, "type", type);
+  buttonNS.setAttributeNS(null, "id", id);
+  buttonNS.setAttributeNS(null, "class", className);
+  return buttonNS;
+}
+
+function handleIncludeButton(svg, parentContainer, levelData) {
+  const { id, level, difficulty, name, origin } = levelData;
+  let button = createButtonElement("submit", `level-${levelData.id}`, LEVEL_CLASS);
+  button.addEventListener("click", () => {
+    loadLevelHandler(levelData);
+  });
+  button.appendChild(svg);
+  parentContainer.appendChild(button);
+}
+
+export function createCardElement(
+  title,
+  measure,
+  colour,
+  parentContainerHtmlId,
+  width,
+  height,
+  includeButton = false,
+  levelData = {}
+) {
+  
+  let parentContainer = document.getElementById(parentContainerHtmlId);
+  if ((!width && !height) || !parentContainer) {
     return;
   }
-  const padding = 10;
-  let svg = getSvg(width + padding, height + padding);
-  let node = document.getElementById(container);
-  if (node) {
-    node.appendChild(svg);
+
+
+  // tech debt: using includeButton to determine if card is for guess or level
+  let svg = createSvgElement(width + CARD_PADDING, height + CARD_PADDING, includeButton ? "level-card" : "guess-card");
+  if (includeButton) {
+    handleIncludeButton(svg, parentContainer, levelData);
+  } else {
+    parentContainer.appendChild(svg);
   }
-
-  let r = getRect(colour, width, height);
+  let r = createRectElement(colour, width, height);
   svg.appendChild(r);
-
-  const textCoordinateX = "30";
-  const textCoordinateY = "180";
-  let t1 = getText(textCoordinateX, title);
+  let t1 = createTextElement(TEXT_COORDINATES.X, title);
   svg.appendChild(t1);
-  let t2 = getText(textCoordinateY, metadata);
+  let t2 = createTextElement(TEXT_COORDINATES.Y, measure);
   svg.appendChild(t2);
+
+  console.log('create card element successfully called!');
 }

--- a/scripts/util/guess.js
+++ b/scripts/util/guess.js
@@ -30,14 +30,14 @@ export function isGuessValid(guess, countryData) {
  * @return {boolean} only true if the guess already exists.
  */
 export function isGuessADuplicate(guess, currentLevelId) {
-  let id = localStorage.getItem("id");
+  let id = localStorage.getItem("userId");
   let foundDuplicateGuess = false;
   if (id) {
     // handle duplicate guess
     let storedLevels = JSON.parse(localStorage.getItem("levels"));
-    console.log(`storedLevels is ${storedLevels}`);
     if (storedLevels) {
       const level = storedLevels.find((l) => l.id == currentLevelId);
+      console.log(`isGuessADuplicate ${level} ${currentLevelId}`);
       if (level) {
         foundDuplicateGuess = level.guesses.find((g) => g.country == toTitleCase(guess.country));
       }

--- a/styles/main.css
+++ b/styles/main.css
@@ -54,3 +54,22 @@ dialog p {
 #levels svg {
 	padding: 4px 0px 4px 0px;
 }
+
+#levelDialog #levels-rounded-corners #levels {
+  button:hover svg rect {
+    stroke: #005786;
+    fill: #005786;  
+  }
+
+  button {
+    margin: 0;
+    background-color: #003049;
+    border: none;
+    color: white;
+    padding: 0px 0px;
+    text-align: center;
+    font-size: 16px;
+    cursor: pointer;
+    transition: 300ms;
+  }
+}


### PR DESCRIPTION
### 20: [Feat] Select and play a level

| # | Story |
|---|---|
| 20 | Select and play a level |

### Description
Add support to select a level:
- Change between levels
- Level card hover styling 
- Levels loaded based on dataset 
- Guess validation is based on the level id
- Local storage is for the correct level

### More info 
Acquired some tech debt with the code writing. It may need a refactor soon!

### Testing
- [x] Self reviewed PR
- [x] UI testing

### Screenshots
<img width="600" alt="image" src="https://github.com/user-attachments/assets/bf4c8b40-dea5-45d7-8eb6-5429616d7ae4" />

<img width="600" alt="image" src="https://github.com/user-attachments/assets/8b5e7608-debb-48d7-9c6f-dd987102cc2c" />